### PR TITLE
Improve the developer experience with a mock server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# github.com/speakeasy-sdks/bolt-alpha-spec
+# Bolt Alpha (SDK & Mock Server)
+
+## Try These APIs Instantly
+
+Want to test the API without setting up the backend?  Click the button below to launch a free mock server on Beeceptor. It fetches the OpenAPI spec and simulates real responses based on your definitions.
+
+<a href="https://beeceptor.com/openapi-mock-server/?url=https://raw.githubusercontent.com/speakeasy-sdks/bolt-alpha-spec/refs/heads/main/openapi.yaml" target="_blank">
+  <img src="https://cdn.beeceptor.com/assets/images/buttons/mock-openapi-with-beeceptor.png" alt="Mock These APIs Instantly" style="height: 75px;">
+</a>
+
+---
+
+If you're integrating with Go, follow the instructions below for SDK usage.
 
 <!-- Start SDK Installation [installation] -->
 ## SDK Installation


### PR DESCRIPTION
### What's Added

- Integrates with [Beeceptor](https://beeceptor.com/openapi-mock-server/) to automatically create a mock server using the `openapi.yaml` from the master branch.
- The spec is fetched from the public URL and served as a live mock API, accessible to anyone.
- All API operations are visualized with their request and response structures, based on the OpenAPI definition.
- This improves developer experience by allowing them to test the APIs instantly—no local setup or tools required.